### PR TITLE
new IBM PAIRS package release v0.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ibmpairs" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: cc09e226b49785f0cbae8876b0a4d62b82451733db5873eb0f304b9ce603fa6a
+  sha256: b022b0801055bcc354535f159f070ddadbb246fe250daadf5d0f2f28c39eed13
 
 build:
   number: 0


### PR DESCRIPTION
Signed-off-by: Conrad M Albrecht <cmalbrec@us.ibm.com>

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` 
* [x] Ensured the license file is being packaged.

@conda-forge-admin, please rerender

# new features
- automatically clean temporary files not used any more
- add utilities to manage multiple IBM PAIRS queries submitted in parallel
- add capability to publish query result to IBM PAIRS web GUI (release of feature on GUI-side pending)

# bug fixes
- make code robust against missing IBM PAIRS query result meta information

